### PR TITLE
Improved docs, bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ await store.disconnect();
 new SecureStore(config: SecureStoreConfig)
 ```
 
-| Option             | Type                            | Required | Description                                       |
-| ------------------ | ------------------------------- | -------- | ------------------------------------------------- |
-| `uid`              | string                          | Yes      | Prefix for Redis keys                             |
-| `secret`           | string                          | Yes      | 32-character encryption secret                    |
-| `redis`            | RedisOptions \| { url: string } | Yes      | Redis connection config                           |
-| `allowWeakSecrets` | boolean                         | No       | Bypass secret strength validation (default false) |
+| Option             | Type                            | Required | Description                                                       |
+| ------------------ | ------------------------------- | -------- | ----------------------------------------------------------------- |
+| `uid`              | string                          | Yes      | Unique prefix for Redis keys (e.g., `"myApp"`, `"myApp:sessions"`) |
+| `secret`           | string                          | Yes      | 32-character encryption secret. Use `SecretValidator.generate()`. |
+| `redis`            | RedisOptions \| { url: string } | Yes      | Redis connection config                                           |
+| `allowWeakSecrets` | boolean                         | No       | Bypass secret strength validation (default: false)                |
 
 ### Methods
 
@@ -56,71 +56,147 @@ Encrypt and store data.
 
 #### `get<T>(key: string, postfix?: string): Promise<T | null>`
 
-Retrieve and decrypt data. Returns `null` if not found.
+Retrieve and decrypt data. Returns `null` if not found or decryption fails.
 
 #### `delete(key: string, postfix?: string): Promise<number>`
 
 Delete data. Returns count of deleted keys.
 
-#### `disconnect(): Promise<void>`
+#### `disconnect(client?: Redis): Promise<void>`
 
-Close Redis connection.
-
-#### `namespace<T>(name: string): TypedNamespace<T>`
-
-Create a typed namespace for type-safe operations.
-
-```typescript
-interface UserSchema {
-    profile: { name: string; age: number };
-    settings: { theme: string };
-}
-
-const users = store.namespace<UserSchema>("users");
-await users.save("profile", { name: "John", age: 30 });
-const profile = await users.get("profile");
-```
+Close Redis connection. Optionally pass a specific Redis client to disconnect.
 
 ### Properties
 
 - `client: Redis | undefined` - The underlying ioredis client
 - `isConnected: boolean` - Connection status
 
-### SecretValidator
+## Namespaces
+
+Namespaces allow you to organize data with type-safe operations. Each namespace acts as an isolated partition within the same store.
 
 ```typescript
+const store = new SecureStore({
+    uid: "myApp",
+    secret: SecretValidator.generate(),
+    redis: { url: "redis://localhost:6379" },
+});
+await store.connect();
+
+// Create a typed namespace
+interface UserSchema {
+    profile: { name: string; age: number };
+    settings: { theme: string; notifications: boolean };
+}
+
+const users = store.namespace<UserSchema>("users");
+
+// Type-safe operations
+await users.save("profile", { name: "John", age: 30 });
+await users.save("settings", { theme: "dark", notifications: true });
+
+const profile = await users.get("profile"); // { name: string; age: number } | null
+const settings = await users.get("settings");
+
+await users.delete("profile");
+```
+
+### Namespace Methods
+
+Each namespace provides the same core operations as the store:
+
+- `get<K>(key: K): Promise<T[K] | null>`
+- `save<K>(key: K, data: T[K]): Promise<void>`
+- `delete<K>(key: K): Promise<number>`
+
+### Namespace Isolation
+
+Data in different namespaces is completely isolated:
+
+```typescript
+const users = store.namespace("users");
+const sessions = store.namespace("sessions");
+
+await users.save("data", "user-data");
+await sessions.save("data", "session-data");
+
+await users.get("data");    // "user-data"
+await sessions.get("data"); // "session-data"
+await store.get("data");    // null (root store is separate)
+```
+
+## SecretValidator
+
+Utility class for generating and validating encryption secrets.
+
+```typescript
+import { SecretValidator } from "secure-store-redis";
+
 // Generate a secure 32-character secret
 const secret = SecretValidator.generate();
 
 // Validate secret strength
 const result = SecretValidator.validate(secret);
-// { valid: true } or { valid: false, reason: "..." }
+if (!result.valid) {
+    console.error(result.reason);
+}
 ```
 
-### Error Classes
+### Validation Rules
 
-- `SecureStoreError` - Base error class
-- `ConnectionError` - Redis connection failures
-- `EncryptionError` - Encryption/decryption failures
-- `ValidationError` - Invalid configuration or input
+Secrets must:
+- Be exactly 32 characters
+- Have sufficient entropy (Shannon entropy ≥ 4.0)
+- Not contain weak patterns (repeated chars, sequential numbers, etc.)
+- Contain at least 3 of: uppercase, lowercase, numbers, special characters
 
-## Security
+## Error Handling
+
+All errors extend `SecureStoreError` and include a `code` property for programmatic handling.
+
+```typescript
+import {
+    SecureStoreError,
+    ConnectionError,
+    EncryptionError,
+    ValidationError,
+} from "secure-store-redis";
+
+try {
+    await store.connect();
+} catch (err) {
+    if (err instanceof ConnectionError) {
+        console.error(`Connection failed (${err.code}):`, err.message);
+        // err.code === "CONNECTION_ERROR"
+    }
+}
+```
+
+| Error Class       | Code                 | When Thrown                          |
+| ----------------- | -------------------- | ------------------------------------ |
+| `ConnectionError` | `CONNECTION_ERROR`   | Redis connection failures            |
+| `EncryptionError` | `ENCRYPTION_ERROR`   | Encryption/decryption failures       |
+| `ValidationError` | `VALIDATION_ERROR`   | Invalid configuration, keys, or data |
+
+## Security Best Practices
 
 - Store secrets in environment variables, not code
 - Use `SecretValidator.generate()` for cryptographically secure secrets
 - Enable Redis authentication and TLS in production
-- Rotate secrets periodically
+- Use unique `uid` values per application/environment to prevent data collisions
+- Rotate secrets periodically (requires re-encryption of existing data)
 
 ## Migration from v3.x
 
 ### Breaking Changes
 
-| Change               | Migration                                 |
-| -------------------- | ----------------------------------------- |
-| `uid` required       | Add explicit `uid` to constructor         |
-| `connect()` required | Call `await store.connect()` before use   |
-| AES-256-GCM          | Re-encrypt existing data (format changed) |
-| Secret validation    | Use strong secrets or `allowWeakSecrets`  |
+| Change               | Migration                                  |
+| -------------------- | ------------------------------------------ |
+| `uid` required       | Add explicit `uid` to constructor          |
+| `secret` required    | Use `SecretValidator.generate()` or provide your own |
+| `connect()` required | Call `await store.connect()` before use    |
+| AES-256-GCM          | Re-encrypt existing data (format changed)  |
+| Secret validation    | Use strong secrets or set `allowWeakSecrets: true` |
 
 ### Example
 
@@ -136,6 +212,22 @@ const store = new SecureStore({
     redis: { url: "..." },
 });
 await store.connect();
+```
+
+## TypeScript
+
+Full TypeScript support with exported types:
+
+```typescript
+import SecureStore, {
+    SecureStoreConfig,
+    TypedNamespace,
+    SecretValidator,
+    SecureStoreError,
+    ConnectionError,
+    EncryptionError,
+    ValidationError,
+} from "secure-store-redis";
 ```
 
 ## License

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, test, describe, afterAll, beforeAll } from "./test-compat.ts";
 
-import SecureStore from "./index.ts";
+import SecureStore, { SecretValidator } from "./index.ts";
 
 const complexObj = {
     foo: "bar",
@@ -91,6 +91,8 @@ describe("SecureStore", () => {
     describe("Error handling", () => {
         test("invalid connection config", async () => {
             const ss = new SecureStore({
+                uid: "error-test",
+                secret: "823HD8DG26JA0LK1239Hgb651TWfs0j1",
                 redis: {
                     url: "redis://127.0.0.1:6378",
                 },
@@ -107,6 +109,26 @@ describe("SecureStore", () => {
                         error.message.includes("Connection is closed"),
                 ).toEqual(true);
             }
+        });
+
+        test("weak secret rejected by default", () => {
+            expect(() => {
+                new SecureStore({
+                    uid: "test",
+                    secret: "tooshort",
+                    redis: { url: "redis://127.0.0.1:6379" },
+                });
+            }).toThrow("Invalid secret");
+        });
+
+        test("weak secret allowed with allowWeakSecrets", () => {
+            const ss = new SecureStore({
+                uid: "test",
+                secret: "weakbutallowed",
+                redis: { url: "redis://127.0.0.1:6379" },
+                allowWeakSecrets: true,
+            });
+            expect(ss).toBeDefined();
         });
     });
 
@@ -162,11 +184,11 @@ describe("SecureStore", () => {
 
         beforeAll(async () => {
             store = new SecureStore({
-                secret: "dh348djGk548fKs83kDs8kdSfGssgJfg",
+                uid: "invocations-test",
+                secret: "dh348djGk548fKs83kDs8Kj!@ssgJfg1",
                 redis: {
                     url: "redis://127.0.0.1:6379",
                 },
-                allowWeakSecrets: true,
             });
             await store.connect();
         });
@@ -175,7 +197,7 @@ describe("SecureStore", () => {
             await store.disconnect();
         });
 
-        test("without uid", async () => {
+        test("basic save and get", async () => {
             await store.save("foo", "hello");
             expect(await store.get("foo")).toEqual("hello");
         });
@@ -337,6 +359,155 @@ describe("SecureStore", () => {
             afterAll(async () => {
                 await ss3.disconnect();
             });
+        });
+    });
+
+    describe("Namespace", () => {
+        let store: SecureStore;
+
+        beforeAll(async () => {
+            store = new SecureStore({
+                uid: "namespace-test",
+                secret: "823HD8DG26JA0LK1239Hgb651TWfs0j1",
+                redis: {
+                    url: "redis://127.0.0.1:6379",
+                },
+            });
+            await store.connect();
+        });
+
+        afterAll(async () => {
+            await store.disconnect();
+        });
+
+        test("save and get with namespace", async () => {
+            const users = store.namespace("users");
+            await users.save("profile", { name: "John", age: 30 });
+            const profile = await users.get("profile");
+            expect(profile).toEqual({ name: "John", age: 30 });
+        });
+
+        test("namespaces are isolated from each other", async () => {
+            const users = store.namespace("users");
+            const settings = store.namespace("settings");
+
+            await users.save("key1", "user-value");
+            await settings.save("key1", "settings-value");
+
+            expect(await users.get("key1")).toEqual("user-value");
+            expect(await settings.get("key1")).toEqual("settings-value");
+        });
+
+        test("namespace is isolated from root store", async () => {
+            const ns = store.namespace("isolated");
+            await store.save("rootkey", "root-value");
+            await ns.save("rootkey", "namespace-value");
+
+            expect(await store.get("rootkey")).toEqual("root-value");
+            expect(await ns.get("rootkey")).toEqual("namespace-value");
+        });
+
+        test("delete within namespace", async () => {
+            const ns = store.namespace("delete-test");
+            await ns.save("to-delete", "value");
+            expect(await ns.get("to-delete")).toEqual("value");
+
+            const deleted = await ns.delete("to-delete");
+            expect(deleted).toEqual(1);
+            expect(await ns.get("to-delete")).toEqual(null);
+        });
+
+        test("typed namespace with schema", async () => {
+            interface UserSchema {
+                profile: { name: string; email: string };
+                preferences: { theme: string; notifications: boolean };
+            }
+
+            const users = store.namespace<UserSchema>("typed-users");
+            await users.save("profile", { name: "Jane", email: "jane@example.com" });
+            await users.save("preferences", { theme: "dark", notifications: true });
+
+            const profile = await users.get("profile");
+            const prefs = await users.get("preferences");
+
+            expect(profile).toEqual({ name: "Jane", email: "jane@example.com" });
+            expect(prefs).toEqual({ theme: "dark", notifications: true });
+        });
+
+        test("get non-existent key in namespace returns null", async () => {
+            const ns = store.namespace("empty-ns");
+            expect(await ns.get("nonexistent")).toEqual(null);
+        });
+
+        test("empty namespace name throws error", () => {
+            expect(() => store.namespace("")).toThrow("Namespace name must be a non-empty string");
+        });
+    });
+
+    describe("Falsy values", () => {
+        let store: SecureStore;
+
+        beforeAll(async () => {
+            store = new SecureStore({
+                uid: "falsy-test",
+                secret: "823HD8DG26JA0LK1239Hgb651TWfs0j1",
+                redis: {
+                    url: "redis://127.0.0.1:6379",
+                },
+            });
+            await store.connect();
+        });
+
+        afterAll(async () => {
+            await store.disconnect();
+        });
+
+        test("can store and retrieve 0", async () => {
+            await store.save("zero", 0);
+            expect(await store.get("zero")).toEqual(0);
+        });
+
+        test("can store and retrieve false", async () => {
+            await store.save("false", false);
+            expect(await store.get("false")).toEqual(false);
+        });
+
+        test("can store and retrieve empty string", async () => {
+            await store.save("empty", "");
+            expect(await store.get("empty")).toEqual("");
+        });
+
+        test("null data throws error", async () => {
+            await expect(store.save("null", null)).rejects.toThrow("No data provided");
+        });
+
+        test("undefined data throws error", async () => {
+            await expect(store.save("undefined", undefined)).rejects.toThrow("No data provided");
+        });
+    });
+
+    describe("SecretValidator", () => {
+
+        test("generate creates 32-character string", () => {
+            const secret = SecretValidator.generate();
+            expect(secret.length).toEqual(32);
+        });
+
+        test("validate rejects short secrets", () => {
+            const result = SecretValidator.validate("short");
+            expect(result.valid).toEqual(false);
+            expect(result.reason).toContain("32 characters");
+        });
+
+        test("validate rejects weak patterns", () => {
+            const result = SecretValidator.validate("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            expect(result.valid).toEqual(false);
+        });
+
+        test("validate accepts strong secrets", () => {
+            const secret = SecretValidator.generate();
+            const result = SecretValidator.validate(secret);
+            expect(result.valid).toEqual(true);
         });
     });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,10 +159,19 @@ export class SecretValidator {
     static generate(): string {
         const chars =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
-        const bytes = randomBytes(32);
+        const charsLength = chars.length;
+        // Use rejection sampling to avoid modulo bias
+        const maxValidByte = 256 - (256 % charsLength);
+
         let secret = "";
-        for (let i = 0; i < 32; i++) {
-            secret += chars[bytes[i] % chars.length];
+        while (secret.length < 32) {
+            const bytes = randomBytes(64);
+            for (const byte of bytes) {
+                if (byte < maxValidByte) {
+                    secret += chars[byte % charsLength];
+                    if (secret.length === 32) break;
+                }
+            }
         }
         return secret;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,10 +153,18 @@ export class SecretValidator {
     }
 
     /**
-     * Generate cryptographically secure secret
+     * Generate cryptographically secure 32-character secret.
+     * Uses a mix of uppercase, lowercase, numbers, and special characters.
      */
     static generate(): string {
-        return randomBytes(16).toString("hex");
+        const chars =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
+        const bytes = randomBytes(32);
+        let secret = "";
+        for (let i = 0; i < 32; i++) {
+            secret += chars[bytes[i] % chars.length];
+        }
+        return secret;
     }
 }
 
@@ -165,13 +173,14 @@ export class SecretValidator {
  */
 export interface SecureStoreConfig {
     /**
-     * A unique ID which can be used to prefix data stored in Redis
+     * A unique ID which is used to prefix data stored in Redis.
      */
     uid: string;
     /**
-     * A 32 character encryption secret, it will be automatically generated if not provided
+     * A 32 character encryption secret.
+     * Use SecretValidator.generate() to create a cryptographically secure secret.
      */
-    secret?: string;
+    secret: string;
     /**
      * Redis connect config object
      */
@@ -219,7 +228,15 @@ export default class SecureStore {
         if (typeof cfg.redis !== "object") {
             cfg.redis = {};
         }
-        // Set default for allowWeakSecrets
+        // Validate secret unless allowWeakSecrets is true
+        if (!cfg.allowWeakSecrets) {
+            const validation = SecretValidator.validate(cfg.secret);
+            if (!validation.valid) {
+                throw new ValidationError(
+                    `Invalid secret: ${validation.reason}`,
+                );
+            }
+        }
         cfg.allowWeakSecrets = cfg.allowWeakSecrets ?? false;
         this.config = cfg as Required<SecureStoreConfig>;
     }
@@ -260,6 +277,7 @@ export default class SecureStore {
                     redisConfig = {
                         host: url.hostname,
                         port: url.port ? Number.parseInt(url.port, 10) : 6379,
+                        username: url.username || undefined,
                         password: url.password || undefined,
                         db:
                             url.pathname.length > 1
@@ -308,7 +326,7 @@ export default class SecureStore {
         if (typeof key !== "string") {
             throw new ValidationError("No hash key specified");
         }
-        if (!data) {
+        if (data === undefined || data === null) {
             throw new ValidationError("No data provided, nothing to save");
         }
         const suffix = postfix ? `:${postfix}` : "";
@@ -453,22 +471,26 @@ export default class SecureStore {
     }
 
     /**
-     * Create a typed namespace for type-safe operations
+     * Create a typed namespace for type-safe operations.
+     * Data is stored with the namespace as a postfix to the uid.
      */
     namespace<
         TSchema extends Record<string, unknown> = Record<string, unknown>,
     >(name: string): TypedNamespace<TSchema> {
-        const postfix = name ? `:${name}` : "";
-
+        if (!name || typeof name !== "string") {
+            throw new ValidationError(
+                "Namespace name must be a non-empty string",
+            );
+        }
         return {
             get: async <K extends keyof TSchema>(key: K) => {
-                return this.get<TSchema[K]>(String(key), postfix);
+                return this.get<TSchema[K]>(String(key), name);
             },
             save: async <K extends keyof TSchema>(key: K, data: TSchema[K]) => {
-                await this.save(String(key), data, postfix);
+                await this.save(String(key), data, name);
             },
             delete: async <K extends keyof TSchema>(key: K) => {
-                return this.delete(String(key), postfix);
+                return this.delete(String(key), name);
             },
         } as TypedNamespace<TSchema>;
     }

--- a/src/test-compat.ts
+++ b/src/test-compat.ts
@@ -10,6 +10,12 @@ type HookFn = (fn: () => void | Promise<void>) => void;
 
 interface Expect {
     toEqual(expected: unknown): void;
+    toContain(expected: unknown): void;
+    toBeDefined(): void;
+    toThrow(expected?: string | RegExp): void;
+    rejects: {
+        toThrow(expected?: string | RegExp): Promise<void>;
+    };
 }
 
 type ExpectFn = (actual: unknown) => Expect;
@@ -45,6 +51,59 @@ const { describe, test, beforeAll, afterAll, expect } =
         const expectFn: ExpectFn = (actual: unknown): Expect => ({
             toEqual(expected: unknown) {
                 assert.deepStrictEqual(actual, expected);
+            },
+            toContain(expected: unknown) {
+                assert.ok(
+                    String(actual).includes(String(expected)),
+                    `Expected "${actual}" to contain "${expected}"`,
+                );
+            },
+            toBeDefined() {
+                assert.ok(actual !== undefined, "Expected value to be defined");
+            },
+            toThrow(expected?: string | RegExp) {
+                let threw = false;
+                let error: Error | undefined;
+                try {
+                    (actual as () => void)();
+                } catch (e) {
+                    threw = true;
+                    error = e as Error;
+                }
+                assert.ok(threw, "Expected function to throw");
+                if (expected && error) {
+                    const matches =
+                        typeof expected === "string"
+                            ? error.message.includes(expected)
+                            : expected.test(error.message);
+                    assert.ok(
+                        matches,
+                        `Expected error message "${error.message}" to match "${expected}"`,
+                    );
+                }
+            },
+            rejects: {
+                async toThrow(expected?: string | RegExp) {
+                    let threw = false;
+                    let error: Error | undefined;
+                    try {
+                        await (actual as Promise<unknown>);
+                    } catch (e) {
+                        threw = true;
+                        error = e as Error;
+                    }
+                    assert.ok(threw, "Expected promise to reject");
+                    if (expected && error) {
+                        const matches =
+                            typeof expected === "string"
+                                ? error.message.includes(expected)
+                                : expected.test(error.message);
+                        assert.ok(
+                            matches,
+                            `Expected error message "${error.message}" to match "${expected}"`,
+                        );
+                    }
+                },
             },
         });
 


### PR DESCRIPTION
  - Made secret a required config option and added validation in constructor
  - Fixed SecretValidator.generate() to produce secrets that pass validation (proper character variety)
  - Fixed modulo bias in SecretValidator.generate() using rejection sampling
  - Fixed namespace double-colon bug (uid::namespace → uid:namespace)
  - Added namespace name validation (rejects empty strings)
  - Fixed save() to accept falsy values (0, false, "")
  - Fixed Redis URL parsing to include username
  - Added comprehensive tests for namespaces, SecretValidator, and falsy values
  - Documented namespaces, error codes, and TypedNamespace in README
  - Added missing test-compat methods (toThrow, toBeDefined, toContain, rejects) for node:test