### PR TITLE
feat: Optionally specify the number of chars for `SecretValidator.generate()` to generate

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,18 +133,15 @@ await store.get("data");    // null (root store is separate)
 
 Utility class for generating and validating encryption secrets.
 
-```typescript
-import { SecretValidator } from "secure-store-redis";
+### Methods
 
-// Generate a secure 32-character secret
-const secret = SecretValidator.generate();
+#### `generate(length?: number): string`
 
-// Validate secret strength
-const result = SecretValidator.validate(secret);
-if (!result.valid) {
-    console.error(result.reason);
-}
-```
+Generate a cryptographically secure secret. Defaults to 32 characters if no length specified.
+
+#### `validate(secret: string): { valid: boolean; reason?: string }`
+
+Validate secret strength against security requirements.
 
 ### Validation Rules
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -488,9 +488,27 @@ describe("SecureStore", () => {
 
     describe("SecretValidator", () => {
 
-        test("generate creates 32-character string", () => {
+        test("generate creates 32-character string by default", () => {
             const secret = SecretValidator.generate();
             expect(secret.length).toEqual(32);
+        });
+
+        test("generate creates string of specified length", () => {
+            const secret16 = SecretValidator.generate(16);
+            expect(secret16.length).toEqual(16);
+            
+            const secret64 = SecretValidator.generate(64);
+            expect(secret64.length).toEqual(64);
+        });
+
+        test("concatenated secrets pass validation", () => {
+            const part1 = SecretValidator.generate(16);
+            const part2 = SecretValidator.generate(16);
+            const concatenated = part1 + part2;
+            
+            expect(concatenated.length).toEqual(32);
+            const result = SecretValidator.validate(concatenated);
+            expect(result.valid).toEqual(true);
         });
 
         test("validate rejects short secrets", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,10 +153,11 @@ export class SecretValidator {
     }
 
     /**
-     * Generate cryptographically secure 32-character secret.
+     * Generate cryptographically secure secret.
      * Uses a mix of uppercase, lowercase, numbers, and special characters.
+     * @param length - Number of characters to generate (defaults to 32)
      */
-    static generate(): string {
+    static generate(length: number = 32): string {
         const chars =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
         const charsLength = chars.length;
@@ -164,12 +165,12 @@ export class SecretValidator {
         const maxValidByte = 256 - (256 % charsLength);
 
         let secret = "";
-        while (secret.length < 32) {
+        while (secret.length < length) {
             const bytes = randomBytes(64);
             for (const byte of bytes) {
                 if (byte < maxValidByte) {
                     secret += chars[byte % charsLength];
-                    if (secret.length === 32) break;
+                    if (secret.length === length) break;
                 }
             }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -157,7 +157,7 @@ export class SecretValidator {
      * Uses a mix of uppercase, lowercase, numbers, and special characters.
      * @param length - Number of characters to generate (defaults to 32)
      */
-    static generate(length: number = 32): string {
+    static generate(length = 32): string {
         const chars =
             "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
         const charsLength = chars.length;


### PR DESCRIPTION
Optionally specify the number of chars for `SecretValidator.generate()` to generate