### PR TITLE
fix: Fix reconnect after disconnect with internal client

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -229,6 +229,31 @@ describe("SecureStore", () => {
         });
     });
 
+    describe("Reconnect", () => {
+        test("connect works after disconnect with internal client", async () => {
+            const store = new SecureStore({
+                uid: "reconnect-test",
+                secret: "823HD8DG26JA0LK1239Hgb651TWfs0j1",
+                redis: {
+                    url: "redis://127.0.0.1:6379",
+                },
+            });
+
+            await store.connect();
+            await store.save("first", "value1");
+            expect(await store.get("first")).toEqual("value1");
+
+            await store.disconnect();
+            expect(store.isConnected).toEqual(false);
+
+            await store.connect();
+            await store.save("second", "value2");
+            expect(await store.get("second")).toEqual("value2");
+
+            await store.disconnect();
+        });
+    });
+
     describe("Long UID", () => {
         const ss = new SecureStore({
             uid: "secure-store-redis-test1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,6 +285,9 @@ export default class SecureStore {
             } else {
                 log("Redis client quit called");
                 await client.quit();
+                if (client === this.client) {
+                    this.client = undefined;
+                }
             }
             this.connected = false;
         }


### PR DESCRIPTION

- Add a regression test that verifies connect works after disconnect with an internal Redis client.
- Clear internal client reference on disconnect so subsequent connect creates a new client.

