### PR TITLE
chore: improve release process and CI

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,5 +1,7 @@
 name: Compliance
 on:
+    push:
+        branches: [master]
     pull_request:
 
 jobs:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,36 +1,38 @@
 # Release Checklist
-## Pre-Release Verification
-  
-  - Ensure you're on the master branch
-  - Pull latest changes: git pull origin master
-  - Bump version in package.json
 
-## Local Testing
-  
-  - bun install
-  - bun lint
-  - bun run build
-  - Start Redis
-  - bun test
-  - bun run test:node
-  - Verify built output exists in dist/
+## Automated Release
+
+Run the release script from the master branch:
+
+```sh
+./scripts/release.sh <patch|minor|major>
+```
+
+This will:
+  - Verify you're on master with a clean tree
+  - Pull latest changes
+  - Run lint, build, and tests (Bun + Node)
+  - Bump version in package.json
+  - Commit and tag
+  - Push to origin
+
+## After the Script
+
+  - Create a GitHub Release to trigger npm publish:
+    `gh release create vX.X.X --generate-notes`
+  - The Publish workflow (`.github/workflows/publish.yml`) runs automatically
+    when a GitHub Release is published. It re-runs lint, build, and tests,
+    then publishes to npm using the `NPM_TOKEN` repo secret.
+  - Confirm published version: `npm view secure-store-redis version`
+  - Run verification: `./scripts/verify-published-package.sh`
+
+## Prerequisites
+
+  - The `NPM_TOKEN` secret must be set in the repo's GitHub Settings → Secrets.
+    Use a granular npm access token scoped to the `secure-store-redis` package
+    with publish permission.
 
 ## Documentation Review
 
   - README.md reflects all API changes
   - Breaking changes are clearly documented
-
-## Git & GitHub
-
-  - All changes committed
-  - Create and push tag:
-  git tag vX.X.X
-  git push --tags
-  - Publish: npm publish
-  - Update Github Release Page
-
-## Post-Release Verification
-
-  - Verify GitHub Actions Publish release to npmjs workflow succeeds
-  - Confirm package published: npm view secure-store-redis version shows new version
-  - Run verification package: ./scripts/verify-published-package.sh

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,7 +32,3 @@ This will:
     Use a granular npm access token scoped to the `secure-store-redis` package
     with publish permission.
 
-## Documentation Review
-
-  - README.md reflects all API changes
-  - Breaking changes are clearly documented

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
         "build:js": "bun build ./src/index.ts --outdir ./dist --target node --format esm",
         "build:types": "tsc",
         "build": "bun run build:js && bun run build:types",
+        "release": "./scripts/release.sh",
         "prepublishOnly": "bun run build"
     },
     "devDependencies": {
@@ -62,7 +63,7 @@
     },
     "readmeFilename": "README.md",
     "bugs": {
-        "url": "https://github.com/silverbucekt/secure-store-redis/issues"
+        "url": "https://github.com/silverbucket/secure-store-redis/issues"
     },
     "homepage": "https://github.com/silverbucket/secure-store-redis",
     "dependencies": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+VERSION_TYPE="${1:-}"
+
+if [ -z "$VERSION_TYPE" ]; then
+  echo "Usage: ./scripts/release.sh <patch|minor|major|x.y.z>"
+  exit 1
+fi
+
+# Ensure we're on master
+BRANCH=$(git branch --show-current)
+if [ "$BRANCH" != "master" ]; then
+  echo "Error: must be on master branch (currently on $BRANCH)"
+  exit 1
+fi
+
+# Ensure working tree is clean
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: working tree is not clean"
+  git status --short
+  exit 1
+fi
+
+git pull origin master
+
+echo "Running tests..."
+bun install
+bun run lint
+bun run build
+bun test
+bun run test:node
+
+echo ""
+echo "All checks passed. Bumping version..."
+
+# npm version creates the commit and tag
+npm version "$VERSION_TYPE" --no-git-tag-version
+NEW_VERSION=$(node -p "require('./package.json').version")
+
+git add package.json
+git commit -m "v${NEW_VERSION}"
+git tag "v${NEW_VERSION}"
+
+echo ""
+echo "Pushing tag v${NEW_VERSION}..."
+git push origin master
+git push origin "v${NEW_VERSION}"
+
+echo ""
+echo "=============================================="
+echo "Tag v${NEW_VERSION} pushed."
+echo ""
+echo "Next step: create a GitHub Release for v${NEW_VERSION}"
+echo "  gh release create v${NEW_VERSION} --generate-notes"
+echo ""
+echo "This will trigger the publish workflow to npm."
+echo "After publishing, verify with:"
+echo "  ./scripts/verify-published-package.sh ${NEW_VERSION}"
+echo "=============================================="


### PR DESCRIPTION
## Summary
- Run Compliance CI on push to master (not just PRs), so merged code gets tested
- Add `scripts/release.sh` to automate version bump, tagging, and push
- Rewrite RELEASE.md to reflect the actual workflow: script handles local steps, GitHub Release triggers npm publish via the existing Publish workflow
- Fix typo in package.json `bugs.url` (`silverbucekt` → `silverbucket`)

## Notes
The `NPM_TOKEN` repo secret needs to be added/updated — the Publish workflow has failed on all 3 previous releases due to a 404 from npm.